### PR TITLE
origin/fix/docsUpdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ Todo: Write this up next.
 
 ## Table of Contents
 
-#### Information about our intentions, motivations, and decisions thus fa:.
+#### Information about the intentions, motivations, and decisions behind TurboFan.
 
 - [Who?](#who-built-is-building-turbofan)
 - [What?](#what-is-turbofan)
 - [Why TurboFan?](#why-build-turbofan-motivations)
-- [Why Not *SomeOtherThing*?](#why-not-build-something-else-alternatives)
-- [Why FOSS?](#why-open-source)
+- [Why FOSS?](#why-build-in-public-why-open-source)
 
 #### Information about the TurboFan project and its development:
 
@@ -54,7 +53,7 @@ Todo: Write this up next.
 
 ## Who ~~Built~~ Is Building TurboFan?
 
-TurboFan is built by Gale, a former hydromechanical repair technician and indie developer passionate about
+TurboFan is built by Gale, a former repair technician and noob indie developer. Gale is passionate about
 accessibility, modern developer tooling, and using the advances of machine learning for good.
 
 TurboFan is made possible with support and inspiration from the open source community.
@@ -68,50 +67,64 @@ full-featured support for the Swift language and toolchain to JetBrains editor p
 Inspired by the legacy of AppCode, and the growing, cross-platform Swift community, TurboFan’s goal is to make Swift
 development accessible, customizable, and fun for any and every developer interested in coding with Swift.
 
-Most of all, TurboFan is a response to the inadequacy of Xcode and VSCode to meet the needs of large swaths of modern
-developers, including disabled devs, and anyone who just wants to build awesome tools for their IDE and the language
-they enjoy most.
+Most of all, TurboFan is a response to the inadequacy of Xcode and VSCode to meet the needs of many
+developers, including disabled devs, and anyone who just wants to build awesome tools for their preferred IDE and
+language.
 
 ## Why Build Turbofan? (Motivations)
 
+#### And why not just build something else?
+
 I started TurboFan after a long search for an accessible, extensible, and genuinely usable Swift IDE outside of Xcode.
-As a disabled indie developer with endless ideas for creating better dev tools, I hit wall after wall as I spent the
-past six months finally learning how to program. From my first experiences with Xcode back in January, it was clear to
+As a disabled indie developer with endless ideas for creating better dev tools, I hit wall after wall spending the
+past six months learning how to program. From my first experiences with Xcode back in January, it was clear to
 me that this would be yet another long journey of building my own solutions to structural problems.
 
 Xcode and macOS may have class-leading accessibility, and Apple may delight in raising that bar year after year, but
 that same bar is still regularly used for limbo competitions. It is not enough, and I'm not the type to settle for "Hey,
-it's only half broken, so it's fine!" as an answer. To add insult to injury, Xcode has been locked down since version 8,
-and it's clear that the Alcatraz days are long gone. Fixing things myself would not be possible with the half-baked
-alternatives that Apple approves of, even with the myriad open-source tools the Swift team has developed. I'd love to
-build a dozen SwiftPM accessibility and productivity enhancements that Apple seems perennially allergic to even
-considering. If they ever give developers the proper endpoints to do so, I remain intent on doing just that.
+it's only half broken, so it's fine!" as an answer. To add insult to injury, Apple locked down Xcode in version 8, and
+it's clear that the Alcatraz days won't be coming back. 'XCSourceEditorExtension' was intertesting to explore, but it's
+limitations prevented most of the use-cases I had in mind. The need to pipe data over `XPC` serialized to
+`NSSecureCoding` further complicated my attempts at *creative* usages of the only official path to an Xcode "plugin".
+SwiftPM BuiltTool, XcodeBuildTool, and Command plugins are a more recent, and slightly more useful, development.
+Unfortunately, the `BuildTool` options are just that, build tools. They run during a build, full stop. The command tools
+are hobbled in similar ways to`XCSourceEditorExtension`, but will less Mach, Objective-C, and the inane type
+restrictions of `NSSecureCoding`. Better? Yes. Good? No. After shelving or throwing away more projects than I care to
+admit over about 4 months of learning Swift and the Apple platform, I reached an unfortunate realization. Fixing things
+myself would scarcely be possible with the half-baked alternatives that Apple approves of, even with the myriad
+open-source tools the Swift team has developed. I'd love to just sit down and build a dozen SwiftPM/Xcode accessibility
+and productivity enhancements right now. All the things that Apple seems perennially allergic to even considering. If
+they ever give developers the access or proper endpoints to do so, I remain intent on doing just that.
 
-AppCode, the discontinued IDE that I wish JetBrains had continued supporting, was "sunset" years before I knew what a
-.jar or plist was, along with the closed-source plugin that used to bring Swift to CLion as well.
+AppCode, the discontinued IDE that I wish JetBrains had kept developing, was "sunset" years before I knew what a
+.jar or plist was. The first-party closed-source plugin that used to bring Swift to CLion met a similar fate.
 
 The only active attempt to replicate that plugin I could find was also closed-source and soon-to-be-paid via
 subscription model. Two years in the making, it appears to have a ways to go before reaching the levels of integration
 with the underlying IntelliJ Platform that I need and intend to achieve with TurboFan. While I would've much rather
 joined in contributing to an existing project to improve it, this one was vocally opposed to outside contributions.
 
-Disappointed yet still undeterred, I resolved to build TurboFan on my own. Thus began a month-long journey into the wide
-worlds of Java, Kotlin, IntelliJ, JFlex, BNF, and a whole new universe of unreadable, inaccessible, or plain nonexistant
-documentation. And what a month it has been. This endeavor has been a massive learning experience that I'm very grateful
-for.
+Disappointed, yet undeterred, I resolved to begin building a solution myself. Thus began a month-long journey into
+the wide worlds of Java, Kotlin, IntelliJ, JFlex, BNF. This included a much more familiar journey into the vast sea of
+unreadable, inaccessible, or non-existent developer documentation for *everything*. Well, with the notable exception of
+Java, which has a very well-written manual available freely online, all in one place. Shout out to Oracle for the
+excellent resources at [Dev.Java](https://dev.java/learn/). These were a breath of fresh air for someone like myself.
+I'd grown accustomed to trawling through the typical two-hundred lines of uncommented and overloaded function signatures
+in a generated header that Apple calls "developer documentation." I'd almost forgotten what a good set of docs was like
+to read. Well, *try* to read. Apple's shockingly bad TTS system continues to be the bane of my existance. It's actually
+broken in new and exciting ways just since I started this project. I'll save the details on that for a proper blog/rant
+about the state of Apple's flailing accessibility efforts.
 
-While I may have bit off just a bit more than I could chew at first, the bevy of new skills that I had to learn are sure
-to be worth it in the end. Even at this as-yet-early stage, I feel a new level of confidence in my ability to work with
-complex systems and solve problems effectively in new domains with new languages. This has been a
-highly rewarding experience, one that's still only just beginning, and I’m beyond eager to share what I’ve learned, to
-learn from the wider community in return, and, hopefully, to build a community around this nascent effort to bring
-proper accessibility and full extensibility back to the Swift and Apple dev communities.
+While I may have bitten off more than I could chew at first, the bevy of new skills I've learned along the way are sure
+to be worth it in the end. Even at this early stage, I feel a new level of confidence in my ability to work with complex
+systems. Solving difficult problems effectively in new domains with new languages is challenging but exciting, though a
+bit frustrating as the only option available. Being boxed-in is not my favorite circumstance, but it's never stopped me.
+All things considered, this has been a highly rewarding experience, one that's still only just beginning, and I’m beyond
+eager to share what I’ve learned, to learn from the wider community in return, and, hopefully, to build a community
+around this nascent effort to bring proper accessibility and full extensibility back to the Swift and Apple dev
+communities.
 
-## Why Not Build Something Else? (Alternatives)
-
-// TODO: Write this soon.
-
-## Why Open Source?
+## Why Build in Public? Why Open Source?
 
 // TODO: Rewrite this soon.
 
@@ -127,7 +140,9 @@ this idea: whether you want to contribute code, share feedback, ask questions, o
 #### Active work and near-term plans:
 
 - [x] Proper handling of extended delimiters in Swift string literals.
-- [ ] Complete implementation of SyntaxHighlighting via HighlightingLexer.
+- [x] Complete implementation of lexer-based *syntactic* highlighting via HighlightingLexer.
+- [ ] Fix a few more lexing(a.k.a. tokenizing) (.flex) and parsing (.bnf) bugs.
+- [ ] Implement post-parser *semantic* highlighting via PsiElement tree-walking visitor/annotator setup
 - [ ] Finish improving initial documentation.
 - [ ] Complete the refactoring of README.md
 - [ ] Release: Alpha && Marketplace Early Access

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TurboFan
 
 ![Build](https://github.com/MakeMeMonad/TurboFan/workflows/Build/badge.svg)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/MakeMeMonad/TurboFan?utm_source=oss&utm_medium=github&utm_campaign=MakeMeMonad%2FTurboFan&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 [![Version](https://img.shields.io/jetbrains/plugin/v/MARKETPLACE_ID.svg)](https://plugins.jetbrains.com/plugin/MARKETPLACE_ID)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/MARKETPLACE_ID.svg)](https://plugins.jetbrains.com/plugin/MARKETPLACE_ID)
 ---

--- a/README.md
+++ b/README.md
@@ -7,68 +7,213 @@
 ---
 <!-- Plugin description -->
 
+## Overview of this document in plain language.
+
+[Skip to Table of Contents...](#table-of-contents)
+
+Todo: Write this up next.
+
+---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
+
+## Table of Contents
+
+#### Information about our intentions, motivations, and decisions thus fa:.
+
+- [Who?](#who-built-is-building-turbofan)
+- [What?](#what-is-turbofan)
+- [Why TurboFan?](#why-build-turbofan-motivations)
+- [Why Not *SomeOtherThing*?](#why-not-build-something-else-alternatives)
+- [Why FOSS?](#why-open-source)
+
+#### Information about the TurboFan project and its development:
+
+- [Roadmap](#roadmap)
+    - [Active and in-progress work, plus near-term plans.](#active-work-and-near-term-plans)
+    - [Long-term hopes, dreams, and pipe-dreams for what TurboFan could become.](#pipes-and-dreams)
+- [Current Status](#current-status)
+    - [Current IntelliJ features that are implemented or being worked on now.](#intellij-platform-current-api)
+    - [Future IntelliJ Platform API we're watching excitedly...](#intellij-platform-next-gen-api)
+    - [Features that are still provided via LSP...](#provided-by-sourcekit-lsp)
+- [Resources / Getting Help / Contributing](#resources--getting-help--contributing)
+    - [Discover how to contribute to TurboFan...](\.CONTRIBUTING.md)
+    - [Browse the discussion threads...]()
+    - [Start a new discussion thread...]()
+    - [Browse our open issues...]()
+    - [Open up a new issue...]()
+    - [View our Code of Conduct...]()
+
+#### Technicals:
+
+- [Installation](#installation)
+- [License](#license)
+    - [LICENSE.txt]()
+
+---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
+
 ## Who ~~Built~~ Is Building TurboFan?
 
-TurboFan is built by Gale, a disabled indie developer passionate about accessibility and modern tooling, with support
-from the open source community.
-All contributors welcome!
+TurboFan is built by Gale, a former hydromechanical repair technician and indie developer passionate about
+accessibility, modern developer tooling, and using the advances of machine learning for good.
+
+TurboFan is made possible with support and inspiration from the open source community.
+All contributors are welcome!
 
 ## What is TurboFan?
 
-TurboFan is an in-development plugin for the JetBrains IDE ecosystem, aiming to bring modern, full-featured support for
-the Swift language and toolchain to JetBrains editors—especially CLion. Inspired by the legacy of AppCode and the
-growing, cross-platform Swift community, TurboFan’s goal is to make Swift development accessible, customizable, and fun
-on any platform, for any developer.
+TurboFan is an in-development plugin for the JetBrains IntelliJ Platform. TurboFan is intended to bring modern,
+full-featured support for the Swift language and toolchain to JetBrains editor products—especially CLion.
 
-## Why Turbofan? (Motivations)
+Inspired by the legacy of AppCode, and the growing, cross-platform Swift community, TurboFan’s goal is to make Swift
+development accessible, customizable, and fun for any and every developer interested in coding with Swift.
+
+Most of all, TurboFan is a response to the inadequacy of Xcode and VSCode to meet the needs of large swaths of modern
+developers, including disabled devs, and anyone who just wants to build awesome tools for their IDE and the language
+they enjoy most.
+
+## Why Build Turbofan? (Motivations)
 
 I started TurboFan after a long search for an accessible, extensible, and genuinely usable Swift IDE outside of Xcode.
-As a disabled indie developer, I hit wall after wall: Xcode’s accessibility limitations, the shutdown of AppCode,
-closed-source plugins, and projects with little interest in outside contributions. Most available tools either lacked
-basic features, didn’t support community collaboration, or simply weren’t open.
+As a disabled indie developer with endless ideas for creating better dev tools, I hit wall after wall as I spent the
+past six months finally learning how to program. From my first experiences with Xcode back in January, it was clear to
+me that this would be yet another long journey of building my own solutions to structural problems.
 
-After trying everything from VSCode to Cursor, to NeoVIM, to CLion, only JetBrains’ IDEs struck the right balance—if
-only there was proper Swift support! With AppCode discontinued and other efforts closed to contributors, I decided to
-try building my own.
+Xcode and macOS may have class-leading accessibility, and Apple may delight in raising that bar year after year, but
+that same bar is still regularly used for limbo competitions. It is not enough, and I'm not the type to settle for "Hey,
+it's only half broken, so it's fine!" as an answer. To add insult to injury, Xcode has been locked down since version 8,
+and it's clear that the Alcatraz days are long gone. Fixing things myself would not be possible with the half-baked
+alternatives that Apple approves of, even with the myriad open-source tools the Swift team has developed. I'd love to
+build a dozen SwiftPM accessibility and productivity enhancements that Apple seems perennially allergic to even
+considering. If they ever give developers the proper endpoints to do so, I remain intent on doing just that.
 
-It’s been a massive learning experience—crash-coursing everything from JVM internals and JetBrains plugin APIs, to BNF
-grammars and tokenizers—just to get one of my favorite languages working in my favorite IDE. But it’s also been
-rewarding, and I’m eager to share what I’ve learned and, hopefully, build a community around it.
+AppCode, the discontinued IDE that I wish JetBrains had continued supporting, was "sunset" years before I knew what a
+.jar or plist was, along with the closed-source plugin that used to bring Swift to CLion as well.
+
+The only active attempt to replicate that plugin I could find was also closed-source and soon-to-be-paid via
+subscription model. Two years in the making, it appears to have a ways to go before reaching the levels of integration
+with the underlying IntelliJ Platform that I need and intend to achieve with TurboFan. While I would've much rather
+joined in contributing to an existing project to improve it, this one was vocally opposed to outside contributions.
+
+Disappointed yet still undeterred, I resolved to build TurboFan on my own. Thus began a month-long journey into the wide
+worlds of Java, Kotlin, IntelliJ, JFlex, BNF, and a whole new universe of unreadable, inaccessible, or plain nonexistant
+documentation. And what a month it has been. This endeavor has been a massive learning experience that I'm very grateful
+for.
+
+While I may have bit off just a bit more than I could chew at first, the bevy of new skills that I had to learn are sure
+to be worth it in the end. Even at this as-yet-early stage, I feel a new level of confidence in my ability to work with
+complex systems and solve problems effectively in new domains with new languages. This has been a
+highly rewarding experience, one that's still only just beginning, and I’m beyond eager to share what I’ve learned, to
+learn from the wider community in return, and, hopefully, to build a community around this nascent effort to bring
+proper accessibility and full extensibility back to the Swift and Apple dev communities.
+
+## Why Not Build Something Else? (Alternatives)
+
+// TODO: Write this soon.
 
 ## Why Open Source?
+
+// TODO: Rewrite this soon.
 
 The existing options for Swift outside Xcode are limited and often not truly open. I believe that the best tools come
 from passionate communities, not gatekeeping. TurboFan is open-source because I want to welcome anyone who’s excited by
 this idea: whether you want to contribute code, share feedback, ask questions, or just watch the project grow.
 
 ---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
 
-## Current Features / Status
+## Roadmap
 
-- [x] Parsing/tokenizing foundations (experimental)
-    - Nearly complete coverage of the Swift 6.1 spec, including single pass lexing of string interpolation.
-- [x] Syntax highlighting (partial)
-    - Syntax highlighting for most Swift constructs, with full coverage in progress.
-- [ ] LSP integration (experimental)
-- [ ] Refactoring & navigation (in progress)
-    - Hmmm
-- [ ] SwiftPM project support (planned)
-- [ ] SwiftPM Build System integration (planned)
-- [ ] Marketplace release (soon!)
+#### Active work and near-term plans:
 
-For bleeding-edge status, see the [roadmap](#roadmap) or [issues](https://github.com/MakeMeMonad/TurboFan/issues).
+- [x] Proper handling of extended delimiters in Swift string literals.
+- [ ] Complete implementation of SyntaxHighlighting via HighlightingLexer.
+- [ ] Finish improving initial documentation.
+- [ ] Complete the refactoring of README.md
+- [ ] Release: Alpha && Marketplace Early Access
+    - [ ] Get it stable enough for people to try out and tinker with, without getting super frustrated or anything
+    - [ ] Ponder life, the universe, and how SemVer is *really* supposed to work.
+        - [ ] Just gen a random Double 0\.2\.\*\.\.\<0\.5\.\* \'cause that "feels like an alpha-ish range"
+- [ ] Full implementation of reference resolution via PsiReference
+
+#### Pipes and Dreams™:
+
+TODO: Rewrite this soon.
 
 ---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
 
-## Resources
+## Current Status
+
+Our current feature-set is powered by a mix of IntelliJ Platform API, and the SourceKit-LSP language server. This
+balance will shift over time, as implementation of all available features is completed in the full-fat IntelliJ Platform
+API (eg. PsiReferenceContributor, HighlightingLexer, RenameSupport). This is to ensure the highest level of support and
+quality for Swift on JetBrains IDE products.
+
+Our current focus is on achieving full-support of all IntellliJ Platform features via the current/legacy API (eg. PSI,
+Project Structure Model). As the in-development IntelliJ API (eg. 'Workspace' Model, "Custom Entities", 'Symbols')
+become stable, we will shift resources towards implementing the newer API as well, building upon the success of our
+in-progress PSI-based functionality wherever reasonable.
+
+#### IntelliJ Platform Current API:
+
+- [x] Parsing/tokenizing foundations (implemented, in testing)
+    - Nearly complete coverage of the Swift 6.1 spec, including single pass lexing of string interpolation.
+- [x] LSP Integration (implemented, in testing)
+    - STATUS: Implemented. Limited in availability.
+    - ACTIVITY: Bug-fixes and better configuration are actively in progress.
+    - DETAILS: Implemented via JetBrains first-party API. JetBrains restricts this API, and it is only available for
+      PyCharm Unified (free), as well as their Ultimate/Pro IDEs (Paid).
+    - OUTLOOK: We aim to replace this integration with full, native, IntelliJ Platform support over time. We are
+      commited to ensuring the best, and most widely available, user experience possible.
+- [ ] Syntax highlighting (partial, in progress)
+    - STATUS: Underlying functionality implemented. Highlighting is available for many Swift constructs.
+    - ACTIVITY: Bug-fixes and a complete implementation are in progress.
+    - DETAILS: Based upon 'HighlightingLexer'
+    - OUTLOOK:
+- [ ] PSI Reference Resolution (partial, on hold)
+    - STATUS: Underlying foundation is implemented. One full implementation is in place as a proof of concept.
+    - ACTIVITY: Further work on PSI Reference Resolution is on hold until Syntax Highlighting implementation is
+      complete.
+    - DETAILS: Based upon `PsiReferenceContributor`, `PsiReferenceProvider`, and `PsiReference` classes.
+    - OUTLOOK: Navigation and related functionality are provided by SourceKit-LSP for now.
+- [ ] SwiftPM Project Support (future, in planning)
+    - STATUS:
+    - ACTIVITY:
+    - DETAILS:
+    - OUTLOOK:
+- [ ] Other stuff..?
+- [ ] SwiftPM Build System integration (future, exploring options)
+    - STATUS:
+    - ACTIVITY:
+    - DETAILS:
+    - OUTLOOK:
+
+#### IntelliJ Platform Next-Gen API:
+
+- [ ] `Workspace API` (future)
+    - STATUS: Waiting on third-party plugin availability of `Custom Entities`.
+    - ACTIVITY:
+    - DETAILS:
+    - OUTLOOK:
+- [ ] `Symbols API` (future)
+    - STATUS: Waiting on general availability/stability of the `Symbols` API.
+    - ACTIVITY:
+    - DETAILS:
+    - OUTLOOK:
+
+#### Provided by SourceKit-LSP:
+
+- A lot... Need to get this list done.
+
+---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
+
+## Resources / Getting Help / Contributing
 
 Want to help? Or just curious? Feel free to open issues and discussions, make suggestions, or drop by and say hi. I love
 talking about accessibility, tech, JetBrains APIs, Swift, F#, and all kinds of nerdy topics—don’t be shy!
 Whether you want to help, ask questions, or just lurk, you’re always welcome!
-
----
-
-## Getting Help / Contributing
 
 - See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development, and guidelines.
 - [Code of Conduct](./CODE_OF_CONDUCT.md): All participation should be respectful and inclusive.
@@ -77,29 +222,7 @@ Whether you want to help, ask questions, or just lurk, you’re always welcome!
   email [maintainers@makememonad.com](mailto:maintainers@makememonad.com).
 
 ---
-
-## Roadmap
-
-- [ ] Proper handling of extended delimiters in string literals
-- [ ] Full implementation of reference resolution via PsiReference
-
-_(The roadmap is evolving. For the latest, please see [issues](https://github.com/MakeMeMonad/TurboFan/issues)
-or [project boards](https://github.com/MakeMeMonad/TurboFan/projects)!)_
-
----
-
-## Pipes and Dreams
-
-Blue-sky ideas and wild ambitions for TurboFan’s long-term future!
-
-- Full coverage of IntelliJ feature-set via native endpoints.
-- Implementations for in-development platform features
-    - Workspace API with custom entities
-    - Symbols API
-- Feature parity with the late AppCode
-- Full IDE based upon this foundational plugin
-
----
+[Scroll to Top](#overview-of-this-document-in-plain-language)
 <!-- Plugin description end -->
 
 ## Installation
@@ -131,6 +254,7 @@ For contributors: see [CONTRIBUTING.md](./CONTRIBUTING.md).
   <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>⚙️</kbd> > <kbd>Install plugin from disk...</kbd>
 -->
 ---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
 
 ## License
 
@@ -139,6 +263,7 @@ TurboFan is licensed under the [Apache 2.0 License](LICENSE.txt).
 Plugin based on the [IntelliJ Platform Plugin Template][template].
 
 ---
+[Scroll to Top](#overview-of-this-document-in-plain-language)
 
 [template]: https://github.com/JetBrains/intellij-platform-plugin-template
 

--- a/src/main/grammars/com/makememonad/turbofan/Swift.flex
+++ b/src/main/grammars/com/makememonad/turbofan/Swift.flex
@@ -657,7 +657,7 @@ Underscore = "_"
 	}
 		// RULE: CLOSING DELIMITER
 	"\"" {yybegin(stateStack.pop());return STRING_END;}
-		// RULES: ESCAPE SEQuences, PROHIBITED NEWLINES, STRING CONTENT
+		// RULES: ESCAPE SEQUENCES, PROHIBITED NEWLINES, STRING CONTENT
 	{EscapedCharacter} {return STRING_ESCAPED_SEQUENCE;}
 	[\u000A\u000D] {return BAD_CHARACTER;}
 	{QuotedText} {return STRING_TEXT;}

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/SwiftTokenSets.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/SwiftTokenSets.kt
@@ -7,139 +7,158 @@ import com.makememonad.turbofan.language.swift.psi.SwiftTypes.*
 
 object SwiftTokenSets {
 	
-	val TS_ALL_KEYWORDS: TokenSet
-		get() = create(                /* ...types = */ KW_PND_AVAILABLE,
-					       KW_PND_COLORLITERAL,
-					       KW_PND_ELSE,
-					       KW_PND_ELSEIF,
-					       KW_PND_ENDIF,
-					       KW_PND_FILELITERAL,
-					       KW_PND_IF,
-					       KW_PND_IMAGELITERAL,
-					       KW_PND_KEYPATH,
-					       KW_PND_SELECTOR,
-					       KW_PND_SOURCELOCATION,
-					       KW_PND_UNAVAILABLE,
-					       KW_UPPER_ANY,
-					       KW_LOWER_ANY,
-					       KW_ASSOCIATEDTYPE,
-					       KW_AWAIT,
-					       KW_BORROWING,
-					       KW_BREAK,
-					       KW_CASE,
-					       KW_CLASS,
-					       KW_CONSUMING,
-					       KW_CONTINUE,
-					       KW_DEFAULT,
-					       KW_DEFER,
-					       KW_DEINIT,
-					       KW_DO,
-					       KW_ELSE,
-					       KW_ENUM,
-					       KW_EXTENSION,
-					       KW_FALLTHROUGH,
-					       KW_FALSE,
-					       KW_FILEPRIVATE,
-					       KW_FOR,
-					       KW_FUNC,
-					       KW_GUARD,
-					       KW_IF,
-					       KW_IMPORT,
-					       KW_IN,
-					       KW_INIT,
-					       KW_INOUT,
-					       KW_INTERNAL,
-					       KW_LET,
-					       KW_NIL,
-					       KW_NONISOLATED,
-					       KW_OPEN,
-					       KW_OPERATOR,
-					       KW_PRECEDENCEGROUP,
-					       KW_PRIVATE,
-					       KW_LOWER_PROTOCOL_DECL,
-					       KW_PUBLIC,
-					       KW_REPEAT,
-					       KW_RETURN,
-					       KW_LOWER_SELF,
-					       KW_UPPER_SELF,
-					       KW_STATIC,
-					       KW_STRUCT,
-					       KW_SUPER,
-					       KW_SWITCH,
-					       KW_SUBSCRIPT,
-					       KW_THROWS,
-					       KW_TRUE,
-					       KW_TRY,
-					       KW_TYPEALIAS,
-					       KW_VAR,
-					       KW_WHERE,
-					       KW_WHILE,
-					       KW_CATCH,
-					       KW_THROW,
-					       KW_RETHROWS,
-					       KW_ASSOCIATIVITY,
-					       KW_ASYNC,
-					       KW_CONVENIENCE,
-					       KW_DIDSET,
-					       KW_DYNAMIC,
-					       KW_FINAL,
-					       KW_GET,
-					       KW_INDIRECT,
-					       KW_INFIX,
-					       KW_LAZY,
-					       KW_LEFT,
-					       KW_MUTATING,
-					       KW_NONE,
-					       KW_NONMUTATING,
-					       KW_OPTIONAL,
-					       KW_OVERRIDE,
-					       KW_PACKAGE,
-					       KW_POSTFIX,
-					       KW_PRECEDENCE,
-					       KW_PREFIX,
-					       KW_UPPER_PROTOCOL,
-					       KW_REQUIRED,
-					       KW_RIGHT,
-					       KW_SET,
-					       KW_SOME,
-					       KW_UPPER_TYPE,
-					       KW_UNOWNED,
-					       KW_WEAK,
-					       KW_WILLSET)
-	val TS_ALL_IDENTIFIERS: TokenSet
-		get() = create(/* ...types = */ IDENTIFIER)
+	val TS_ALL_KEYWORDS: TokenSet =
+		    create(/* ...types = */ KW_PND_AVAILABLE,
+			   KW_PND_COLORLITERAL,
+			   KW_PND_ELSE,
+			   KW_PND_ELSEIF,
+			   KW_PND_ENDIF,
+			   KW_PND_FILELITERAL,
+			   KW_PND_IF,
+			   KW_PND_IMAGELITERAL,
+			   KW_PND_KEYPATH,
+			   KW_PND_SELECTOR,
+			   KW_PND_SOURCELOCATION,
+			   KW_PND_UNAVAILABLE,
+			   KW_UPPER_ANY,
+			   KW_LOWER_ANY,
+			   KW_ASSOCIATEDTYPE,
+			   KW_AWAIT,
+			   KW_BORROWING,
+			   KW_BREAK,
+			   KW_CASE,
+			   KW_CLASS,
+			   KW_CONSUMING,
+			   KW_CONTINUE,
+			   KW_DEFAULT,
+			   KW_DEFER,
+			   KW_DEINIT,
+			   KW_DO,
+			   KW_ELSE,
+			   KW_ENUM,
+			   KW_EXTENSION,
+			   KW_FALLTHROUGH,
+			   KW_FALSE,
+			   KW_FILEPRIVATE,
+			   KW_FOR,
+			   KW_FUNC,
+			   KW_GUARD,
+			   KW_IF,
+			   KW_IMPORT,
+			   KW_IN,
+			   KW_INIT,
+			   KW_INOUT,
+			   KW_INTERNAL,
+			   KW_LET,
+			   KW_NIL,
+			   KW_NONISOLATED,
+			   KW_OPEN,
+			   KW_OPERATOR,
+			   KW_PRECEDENCEGROUP,
+			   KW_PRIVATE,
+			   KW_LOWER_PROTOCOL_DECL,
+			   KW_PUBLIC,
+			   KW_REPEAT,
+			   KW_RETURN,
+			   KW_LOWER_SELF,
+			   KW_UPPER_SELF,
+			   KW_STATIC,
+			   KW_STRUCT,
+			   KW_SUPER,
+			   KW_SWITCH,
+			   KW_SUBSCRIPT,
+			   KW_THROWS,
+			   KW_TRUE,
+			   KW_TRY,
+			   KW_TYPEALIAS,
+			   KW_VAR,
+			   KW_WHERE,
+			   KW_WHILE,
+			   KW_CATCH,
+			   KW_THROW,
+			   KW_RETHROWS,
+			   KW_ASSOCIATIVITY,
+			   KW_ASYNC,
+			   KW_CONVENIENCE,
+			   KW_DIDSET,
+			   KW_DYNAMIC,
+			   KW_FINAL,
+			   KW_GET,
+			   KW_INDIRECT,
+			   KW_INFIX,
+			   KW_LAZY,
+			   KW_LEFT,
+			   KW_MUTATING,
+			   KW_NONE,
+			   KW_NONMUTATING,
+			   KW_OPTIONAL,
+			   KW_OVERRIDE,
+			   KW_PACKAGE,
+			   KW_POSTFIX,
+			   KW_PRECEDENCE,
+			   KW_PREFIX,
+			   KW_UPPER_PROTOCOL,
+			   KW_REQUIRED,
+			   KW_RIGHT,
+			   KW_SET,
+			   KW_SOME,
+			   KW_UPPER_TYPE,
+			   KW_UNOWNED,
+			   KW_WEAK,
+			   KW_WILLSET)
+	val TS_ALL_IDENTIFIERS: TokenSet = create(/* ...types = */ IDENTIFIER)
 	val TS_ALL_NUMBERS: TokenSet
-		get() = orSet(/* ...sets = */ TS_ALL_INTEGERS, TS_ALL_FLOATS)
+		get() = orSet(/* ...sets = */ this.TS_ALL_INTEGERS, this.TS_ALL_FLOATS)
 	val TS_ALL_STRINGS: TokenSet
-		get() = orSet(/* ...sets = */TS_SINGLELINE_STRINGS, TS_MULTILINE_STRINGS)
+		get() = orSet(/* ...sets = */this.TS_SINGLELINE_STRINGS, this.TS_MULTILINE_STRINGS)
 	
 	// TODO: Fill this out with all other Operator tokens emitted by the lexer..?
-	val TS_ALL_OPERATORS: TokenSet
-		get() = create(/* ...types = */ OPERATOR, OP_ADD)
+	val TS_ALL_OPERATORS: TokenSet = create(/* ...types = */ OPERATOR, OP_ADD)
 	
 	// TODO: Figure out doc-string comments, get a rule in place for those and a token as well...
 	val TS_ALL_LITERALS: TokenSet
-		get() = orSet(                /* ...sets = */ TS_ALL_STRINGS, TS_ALL_NUMBERS, TS_OTHER_LITERALS)
+		get() = orSet(/* ...sets = */ this.TS_ALL_STRINGS, this.TS_ALL_NUMBERS, this.TS_OTHER_LITERALS)
 	val TS_ALL_COMMENTS: TokenSet
-		get() = orSet(                /* ...sets = */ TS_SINGLELINE_COMMENTS, TS_MULTILINE_COMMENTS)
+		get() = orSet(/* ...sets = */ this.TS_SINGLELINE_COMMENTS, this.TS_MULTILINE_COMMENTS)
 	val TS_OTHER_LITERALS: TokenSet
-		get() = orSet(                /* ...sets = */ TS_REGEXP, TS_BOOLEANS, TS_NILS)
-	val TS_ALL_INTEGERS: TokenSet
-		get() = create(          /* ...types = */ INTEGER_LITERAL, HEX_LITERAL, OCTAL_LITERAL, BINARY_LITERAL)
-	val TS_ALL_FLOATS: TokenSet
-		get() = create(            /* ...types = */ HEX_FLOATING_POINT_LITERAL, DECIMAL_FLOATING_POINT_LITERAL)
-	val TS_SINGLELINE_STRINGS: TokenSet
-		get() = create(                        /* ...types = */ STRING_START, STRING_TEXT, STRING_END)
-	val TS_MULTILINE_STRINGS: TokenSet
-		get() = create(                /* ...types = */ MULTILINE_STRING_START, MULTILINE_STRING_TEXT, MULTILINE_STRING_END)
-	val TS_SINGLELINE_COMMENTS: TokenSet
-		get() = create(                /* ...types = */ SINGLELINE_COMMENT, COMMENT_TEXT)
-	val TS_MULTILINE_COMMENTS: TokenSet
-		get() = create(/* ...types = */ MULTILINE_COMMENT_START, MULTILINE_COMMENT_TEXT, MULTILINE_COMMENT_END)
-	val TS_REGEXP: TokenSet
-		get() = create(/* ...types = */ REGULAR_EXPRESSION_LITERAL)
-	val TS_BOOLEANS: TokenSet
-		get() = create(/* ...types = */ KW_TRUE, KW_FALSE)
-	val TS_NILS: TokenSet
-		get() = create(/* ...types = */ KW_NIL)
+		get() = orSet(/* ...sets = */ this.TS_REGEXP, this.TS_BOOLEANS, this.TS_NILS)
+	val TS_ALL_INTEGERS: TokenSet = create(/* ...types = */ INTEGER_LITERAL, HEX_LITERAL, OCTAL_LITERAL, BINARY_LITERAL)
+	val TS_ALL_FLOATS: TokenSet = create(/* ...types = */ HEX_FLOATING_POINT_LITERAL, DECIMAL_FLOATING_POINT_LITERAL)
+	val TS_SINGLELINE_STRINGS: TokenSet = create(/* ...types = */ STRING_START, STRING_TEXT, STRING_END)
+	val TS_MULTILINE_STRINGS: TokenSet = create(/* ...types = */ MULTILINE_STRING_START, MULTILINE_STRING_TEXT, MULTILINE_STRING_END)
+	val TS_SINGLELINE_COMMENTS: TokenSet = create(/* ...types = */ SINGLELINE_COMMENT, COMMENT_TEXT)
+	val TS_MULTILINE_COMMENTS: TokenSet = create(/* ...types = */ MULTILINE_COMMENT_START, MULTILINE_COMMENT_TEXT, MULTILINE_COMMENT_END)
+	val TS_REGEXP: TokenSet = create(/* ...types = */ REGULAR_EXPRESSION_LITERAL)
+	val TS_BOOLEANS: TokenSet = create(/* ...types = */ KW_TRUE, KW_FALSE)
+	val TS_NILS: TokenSet = create(/* ...types = */ KW_NIL)
+	
+	// TODO: Add remaining sets corresponding to defaults in DefaultLanguageHighlighterColors.java
+	// Well, the ones that I can use with the Highlighting Lexer... Write a psi visitor or annotator for the rest...
+	
+	// Doc comment
+	//Braces
+	// Dot
+	// Semicolon
+	// Parens
+	// Brackets
+	// Label
+	// Constant
+	// Local Var
+	// Reassigned local var
+	// Global var
+	// func decl
+	// func call
+	// parameter
+	// reassigned parameter
+	// class name
+	// interface name
+	// class reference
+	// instance method
+	// instance field
+	// static method
+	// static field
+	// other stuff...
+	// valid string escape
+	// invalid string escape
+	// other stuff...
 }

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/SwiftTokenSets.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/SwiftTokenSets.kt
@@ -124,23 +124,24 @@ object SwiftTokenSets {
 		get() = orSet(/* ...sets = */ this.TS_REGEXP, this.TS_BOOLEANS, this.TS_NILS)
 	val TS_ALL_INTEGERS: TokenSet = create(/* ...types = */ INTEGER_LITERAL, HEX_LITERAL, OCTAL_LITERAL, BINARY_LITERAL)
 	val TS_ALL_FLOATS: TokenSet = create(/* ...types = */ HEX_FLOATING_POINT_LITERAL, DECIMAL_FLOATING_POINT_LITERAL)
-	val TS_SINGLELINE_STRINGS: TokenSet = create(/* ...types = */ STRING_START, STRING_TEXT, STRING_END)
-	val TS_MULTILINE_STRINGS: TokenSet = create(/* ...types = */ MULTILINE_STRING_START, MULTILINE_STRING_TEXT, MULTILINE_STRING_END)
+	val TS_SINGLELINE_STRINGS: TokenSet = create(/* ...types = */ EXTENDED_STRING_START, STRING_START, STRING_TEXT, STRING_END, EXTENDED_STRING_END)
+	val TS_MULTILINE_STRINGS: TokenSet =
+		    create(/* ...types = */ EXTENDED_MULTILINE_STRING_START, MULTILINE_STRING_START, MULTILINE_STRING_TEXT, MULTILINE_STRING_END, EXTENDED_MULTILINE_STRING_END)
 	val TS_SINGLELINE_COMMENTS: TokenSet = create(/* ...types = */ SINGLELINE_COMMENT, COMMENT_TEXT)
 	val TS_MULTILINE_COMMENTS: TokenSet = create(/* ...types = */ MULTILINE_COMMENT_START, MULTILINE_COMMENT_TEXT, MULTILINE_COMMENT_END)
 	val TS_REGEXP: TokenSet = create(/* ...types = */ REGULAR_EXPRESSION_LITERAL)
 	val TS_BOOLEANS: TokenSet = create(/* ...types = */ KW_TRUE, KW_FALSE)
 	val TS_NILS: TokenSet = create(/* ...types = */ KW_NIL)
+	val TS_BRACES: TokenSet = create(/* ...types = */ RBRACE, LBRACE)
+	val TS_DOT: TokenSet = create(/* ...types = */ DOT)
+	val TS_SEMICOLON: TokenSet = create(/* ...types = */ SEMICOLON)
+	val TS_PARENS: TokenSet = create(/* ...types = */ RPAREN, LPAREN)
+	val TS_BRACKETS: TokenSet = create(/* ...types = */ RBRACKET, LBRACKET)
+	val TS_VALID_STRING_ESCAPE: TokenSet = create(/* ...types = */ STRING_ESCAPED_SEQUENCE, MULTILINE_STRING_ESCAPED_SEQUENCE, MULTILINE_STRING_ESCAPED_NEWLINE)
 	
-	// TODO: Add remaining sets corresponding to defaults in DefaultLanguageHighlighterColors.java
-	// Well, the ones that I can use with the Highlighting Lexer... Write a psi visitor or annotator for the rest...
+	// TODO: Still need to add a set for Doc comments, depends on adding .flex rule to tokenize them... maybe grammar instead given they're contextual...
 	
-	// Doc comment
-	//Braces
-	// Dot
-	// Semicolon
-	// Parens
-	// Brackets
+	// TODO: Need to make a highlighting visitor or annotator for these...
 	// Label
 	// Constant
 	// Local Var
@@ -157,8 +158,7 @@ object SwiftTokenSets {
 	// instance field
 	// static method
 	// static field
-	// other stuff...
-	// valid string escape
+	
 	// invalid string escape
-	// other stuff...
+	
 }

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftColorSettingsPage.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftColorSettingsPage.kt
@@ -3,34 +3,52 @@ package com.makememonad.turbofan.language.swift.highlighter
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.*
 import com.makememonad.turbofan.language.swift.SwiftIcons
+import javax.swing.Icon
 
 class SwiftColorSettingsPage: ColorSettingsPage {
 	
-	override fun getDisplayName() = "Swift"
-	override fun getIcon() = SwiftIcons.SwiftFileIcon
-	override fun getHighlighter() = SwiftSyntaxHighlighter()
+	override fun getDisplayName(): String = "Swift (TurboFan)"
+	override fun getIcon(): Icon = SwiftIcons.SwiftFileIcon
+	override fun getHighlighter(): SwiftSyntaxHighlighter = SwiftSyntaxHighlighter()
 	override fun getDemoText(): String = """
-        // Single-line comment
-        /* Multiline
-           comment */
-        let name = "Swift"
-        let number = 123
-        let result = a + b * 2
-        func myFunc(param: Int) -> String { return "\(param)" }
-        struct Person { let id: Int }
+        /* This is a Swift...
+	Multi-line...
+        comment */
+	
+	// This is a Swift Single-line comment
+	// Here's another comment! Wow!
+        let thisString = "Swift string literal"
+        let thisIntegerNumber: Int = 123
+	let thisDouble: Double = 3.9
+        let theResultOfThisExpression = 8.5 + thisDouble * 2.7
+        func withSomeName(param: Int) -> String { return "\(param)" }
+        struct Person {
+		let id: UUID()
+	}
+	
+	@Model
+	final class someSwiftDataStuff {
+	
+		init(){}
+	}
     """.trimIndent()
 	
 	override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey>? = null
 	override fun getAttributeDescriptors(): Array<AttributesDescriptor> = arrayOf(
-		    AttributesDescriptor("Keywords//All", SwiftSyntaxHighlighter.ALL_KEYWORD_KEYS[0]),
-		    AttributesDescriptor("Identifiers//All", SwiftSyntaxHighlighter.ALL_IDENTIFIER_KEYS[0]),
+		    AttributesDescriptor("Keywords//All-Keywords", SwiftSyntaxHighlighter.ALL_KEYWORD_KEYS[0]),
+		    AttributesDescriptor("Identifiers//All-Identifiers", SwiftSyntaxHighlighter.ALL_IDENTIFIER_KEYS[0]),
 		    AttributesDescriptor("Numbers//All", SwiftSyntaxHighlighter.ALL_NUMBER_KEYS[0]),
-		    AttributesDescriptor("Strings//Single-line", SwiftSyntaxHighlighter.SINGLELINE_STRING_KEYS[0]),
-		    AttributesDescriptor("Strings//Multi-line", SwiftSyntaxHighlighter.MULTILINE_STRING_KEYS[0]),
-		    AttributesDescriptor("Operators", SwiftSyntaxHighlighter.ALL_OPERATOR_KEYS[0]),
-		    AttributesDescriptor("Comments//Single-line", SwiftSyntaxHighlighter.SINGLELINE_COMMENT_KEYS[0]),
-		    AttributesDescriptor("Comments//Multi-line", SwiftSyntaxHighlighter.MULTILINE_COMMENT_KEYS[0]),
-										     )
+		    AttributesDescriptor("Strings//Single-line Strings", SwiftSyntaxHighlighter.SINGLELINE_STRING_KEYS[0]),
+		    AttributesDescriptor("Strings//Multi-line Strings", SwiftSyntaxHighlighter.MULTILINE_STRING_KEYS[0]),
+		    AttributesDescriptor("Operator//All-Operators", SwiftSyntaxHighlighter.ALL_OPERATOR_KEYS[0]),
+		    AttributesDescriptor("Comments//Line Comments", SwiftSyntaxHighlighter.SINGLELINE_COMMENT_KEYS[0]),
+		    AttributesDescriptor("Comments//Block Comments", SwiftSyntaxHighlighter.MULTILINE_COMMENT_KEYS[0]),
+		    AttributesDescriptor("Operator//Braces", SwiftSyntaxHighlighter.BRACES_KEYS[0]),
+		    AttributesDescriptor("Operator//Dot", SwiftSyntaxHighlighter.DOT_KEYS[0]),
+		    AttributesDescriptor("Operator//Semicolon", SwiftSyntaxHighlighter.SEMICOLON_KEYS[0]),
+		    AttributesDescriptor("Operator//Parentheses", SwiftSyntaxHighlighter.PARENS_KEYS[0]),
+		    AttributesDescriptor("Operator//Brackets", SwiftSyntaxHighlighter.BRACKETS_KEYS[0]),
+		    AttributesDescriptor("Operator//Valid String Escape", SwiftSyntaxHighlighter.VALID_STRING_ESCAPE_KEYS[0]))
 	
 	override fun getColorDescriptors(): Array<ColorDescriptor> = arrayOf()
 }

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftSyntaxHighlighter.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftSyntaxHighlighter.kt
@@ -10,20 +10,22 @@ import com.makememonad.turbofan.language.swift.lexer.SwiftLexerAdapter
 
 class SwiftSyntaxHighlighter: SyntaxHighlighterBase() { companion object {
 	
-	val ALL_KEYWORD_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD))
-	val ALL_IDENTIFIER_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER))
-	val ALL_NUMBER_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_NUMBER", DefaultLanguageHighlighterColors.NUMBER))
-	val ALL_STRINGS_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_STRING", DefaultLanguageHighlighterColors.STRING))
-	val SINGLELINE_STRING_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_SINGLELINE_STRING", DefaultLanguageHighlighterColors.STRING))
-	val MULTILINE_STRING_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_MULTILINE_STRING", DefaultLanguageHighlighterColors.STRING))
-	val ALL_OPERATOR_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_OPERATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN))
-	val SINGLELINE_COMMENT_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_SINGLELINE_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT))
-	val MULTILINE_COMMENT_KEYS = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_MULTILINE_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT))
+	val ALL_KEYWORD_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD))
+	val ALL_IDENTIFIER_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER))
+	val ALL_NUMBER_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_NUMBER", DefaultLanguageHighlighterColors.NUMBER))
+	val SINGLELINE_STRING_KEYS: Array<TextAttributesKey> =
+		    arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_SINGLELINE_STRING", DefaultLanguageHighlighterColors.STRING))
+	val MULTILINE_STRING_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_MULTILINE_STRING", DefaultLanguageHighlighterColors.STRING))
+	val ALL_OPERATOR_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_OPERATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN))
+	val SINGLELINE_COMMENT_KEYS: Array<TextAttributesKey> =
+		    arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_SINGLELINE_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT))
+	val MULTILINE_COMMENT_KEYS: Array<TextAttributesKey> =
+		    arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_MULTILINE_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT))
 	
 	// TODO: Add the rest of the categories with known default TextAttributeKeys in IntelliJ
 	
 	// ...repeat for COMMENT, KEYWORD, IDENTIFIER, OPERATOR, NUMBER...
-	val EMPTY_KEYS = emptyArray<TextAttributesKey>()
+	val EMPTY_KEYS: Array<TextAttributesKey> = emptyArray<TextAttributesKey>()
 }
 	
 	override fun getHighlightingLexer(): Lexer = SwiftLexerAdapter()
@@ -31,7 +33,6 @@ class SwiftSyntaxHighlighter: SyntaxHighlighterBase() { companion object {
 		SwiftTokenSets.TS_ALL_KEYWORDS.contains(tokenType)        -> ALL_KEYWORD_KEYS
 		SwiftTokenSets.TS_ALL_IDENTIFIERS.contains(tokenType)     -> ALL_IDENTIFIER_KEYS
 		SwiftTokenSets.TS_ALL_NUMBERS.contains(tokenType)         -> ALL_NUMBER_KEYS
-		SwiftTokenSets.TS_ALL_STRINGS.contains(tokenType)         -> ALL_STRINGS_KEYS
 		SwiftTokenSets.TS_SINGLELINE_STRINGS.contains(tokenType)  -> SINGLELINE_STRING_KEYS
 		SwiftTokenSets.TS_MULTILINE_STRINGS.contains(tokenType)   -> MULTILINE_STRING_KEYS
 		SwiftTokenSets.TS_ALL_OPERATORS.contains(tokenType)       -> ALL_OPERATOR_KEYS

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftSyntaxHighlighter.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/highlighter/SwiftSyntaxHighlighter.kt
@@ -23,8 +23,13 @@ class SwiftSyntaxHighlighter: SyntaxHighlighterBase() { companion object {
 		    arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_MULTILINE_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT))
 	
 	// TODO: Add the rest of the categories with known default TextAttributeKeys in IntelliJ
-	
-	// ...repeat for COMMENT, KEYWORD, IDENTIFIER, OPERATOR, NUMBER...
+	val BRACES_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_BRACES", DefaultLanguageHighlighterColors.BRACES))
+	val DOT_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_DOT", DefaultLanguageHighlighterColors.DOT))
+	val SEMICOLON_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON))
+	val PARENS_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_PARENS", DefaultLanguageHighlighterColors.PARENTHESES))
+	val BRACKETS_KEYS: Array<TextAttributesKey> = arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS))
+	val VALID_STRING_ESCAPE_KEYS: Array<TextAttributesKey> =
+		    arrayOf(TextAttributesKey.createTextAttributesKey("SWIFT_VALID_STRING_ESCAPE", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE))
 	val EMPTY_KEYS: Array<TextAttributesKey> = emptyArray<TextAttributesKey>()
 }
 	
@@ -38,6 +43,12 @@ class SwiftSyntaxHighlighter: SyntaxHighlighterBase() { companion object {
 		SwiftTokenSets.TS_ALL_OPERATORS.contains(tokenType)       -> ALL_OPERATOR_KEYS
 		SwiftTokenSets.TS_SINGLELINE_COMMENTS.contains(tokenType) -> SINGLELINE_COMMENT_KEYS
 		SwiftTokenSets.TS_MULTILINE_COMMENTS.contains(tokenType)  -> MULTILINE_COMMENT_KEYS
+		SwiftTokenSets.TS_BRACES.contains(tokenType)              -> BRACES_KEYS
+		SwiftTokenSets.TS_DOT.contains(tokenType)                 -> DOT_KEYS
+		SwiftTokenSets.TS_SEMICOLON.contains(tokenType)           -> SEMICOLON_KEYS
+		SwiftTokenSets.TS_PARENS.contains(tokenType)              -> PARENS_KEYS
+		SwiftTokenSets.TS_BRACKETS.contains(tokenType)            -> BRACKETS_KEYS
+		SwiftTokenSets.TS_VALID_STRING_ESCAPE.contains(tokenType) -> VALID_STRING_ESCAPE_KEYS
 		else                                                      -> EMPTY_KEYS
 	}
 }

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/lsp/SwiftLspServerDescriptor.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/lsp/SwiftLspServerDescriptor.kt
@@ -10,6 +10,10 @@ import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 
+// TODO: Learn LSP Spec more in depth, particularly 2.0+
+// TODO: Dig through the rest of the classes used to build ClientCapabilities,
+//  and map those to the things I need from the LSP spec while the Psi implementations are in progress...
+
 class SwiftLspServerDescriptor(
 	    project: Project, presentableName: String, private val lspBinaryPath: String, vararg roots: VirtualFile,
 			      ): ProjectWideLspServerDescriptor(project, presentableName) {
@@ -36,14 +40,10 @@ class SwiftLspServerDescriptor(
 					this.relativePatternSupport = true
 				}
 				this.executeCommand = ExecuteCommandCapabilities(/* dynamicRegistration = */ false)
-				// Don't set semanticTokens here (removes LSP highlighting support)
 				// semanticTokens = SemanticTokensWorkspaceCapabilities().apply { refreshSupport = true }
 			}
 			textDocument = TextDocumentClientCapabilities().apply { ->
 				synchronization = SynchronizationCapabilities().apply { ->
-					// `dynamicRegistration = false` because the IDE doesn't check dynamically registered capabilities before sending
-					// `didOpen` / `didChange` / `didClose` notifications.
-					// It means that the IDE relies on static capability `LspServer.initializeResult.capabilities.textDocumentSync`
 					dynamicRegistration = false
 					willSave = false
 					willSaveWaitUntil = false
@@ -75,25 +75,9 @@ class SwiftLspServerDescriptor(
 						itemDefaults = listOf("commitCharacters", "editRange", "insertTextFormat", "insertTextMode", "data")
 					}
 				}
+				
 				hover = HoverCapabilities().apply { ->
 					contentFormat = listOf(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT)
-				}
-				val semanticTokensSupport: LspSemanticTokensSupport? = this@SwiftLspServerDescriptor.lspSemanticTokensSupport
-				if(semanticTokensSupport != null) {
-					semanticTokens = SemanticTokensCapabilities().apply { ->
-						requests = SemanticTokensClientCapabilitiesRequests().apply { ->
-							range = Either.forLeft(/* left = */ false)
-							full = Either.forRight(/* right = */ SemanticTokensClientCapabilitiesRequestsFull().apply { ->
-								delta = false
-							})
-							tokenTypes = semanticTokensSupport.tokenTypes
-							tokenModifiers = semanticTokensSupport.tokenModifiers
-							formats = listOf(TokenFormat.Relative)
-							overlappingTokenSupport = true
-							multilineTokenSupport = true
-							serverCancelSupport = false
-						}
-					}
 				}
 				publishDiagnostics = PublishDiagnosticsCapabilities().apply { ->
 					versionSupport = true
@@ -117,7 +101,6 @@ class SwiftLspServerDescriptor(
 				}
 				this.formatting = FormattingCapabilities(/* dynamicRegistration = */ true)
 				this.references = ReferencesCapabilities(/* dynamicRegistration = */ true)
-				this.colorProvider = ColorProviderCapabilities(/* dynamicRegistration = */ true)
 			}
 			this.notebookDocument = null
 			this.window = WindowClientCapabilities().apply { ->
@@ -132,6 +115,7 @@ class SwiftLspServerDescriptor(
 			this.experimental = null
 		}
 	
+	override val lspSemanticTokensSupport: LspSemanticTokensSupport? = null
 	// TODO: After IntelliJ 'Workspace API' stability and implementation,
 	//  consider need for Overriding WorkspaceClientCapabilities and/or getWorkspaceConfiguration
 }

--- a/src/main/kotlin/com/makememonad/turbofan/language/swift/lsp/SwiftLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/makememonad/turbofan/language/swift/lsp/SwiftLspServerSupportProvider.kt
@@ -20,7 +20,7 @@ class SwiftLspServerSupportProvider: LspServerSupportProvider {
 						project = project, presentableName = "TurboFan: SourceKit-LSP", lspBinaryPath = lspPath))
 		}
 		else {
-			notifySourceKitNotFound(project)
+			this.notifySourceKitNotFound(project)
 		}
 	}
 	
@@ -32,9 +32,13 @@ class SwiftLspServerSupportProvider: LspServerSupportProvider {
 	// TODO: Add a link to the notification for quick access to the Swift toolchain download page, preferably for the host os/arch...
 	// TODO: Implement settings page for user-configured path, and link to it from notification...
 	fun notifySourceKitNotFound(project: Project? = null) {
-		NotificationGroupManager.getInstance().getNotificationGroup(/* groupId = */ "TurboFan Notifications").createNotification(
+		NotificationGroupManager
+			    .getInstance()
+			    .getNotificationGroup(/* groupId = */ "TurboFan Notifications")
+			    .createNotification(
 					title = "Could not find SourceKit-LSP",
 					content = "Please install the Swift toolchain or provide the path in settings.",
-					type = NotificationType.ERROR).notify(project)
+					type = NotificationType.ERROR)
+			    .notify(project)
 	}
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,8 +29,6 @@
         <lang.syntaxHighlighterFactory
                 language="swift"
                 implementationClass="com.makememonad.turbofan.language.swift.highlighter.SwiftSyntaxHighlighterFactory"/>
-        <colorSettingsPage
-                implementation="com.makememonad.turbofan.language.swift.highlighter.SwiftColorSettingsPage"/>
         <psi.referenceContributor
                 language="swift"
                 implementation="com.makememonad.turbofan.language.swift.references.SwiftReferenceContributor"/>


### PR DESCRIPTION
Finished implementing syntactic highlighting via SwiftHighlightingLexer. This included improving and expanding SwiftColorSettingsPage, SwiftSyntaxHighlighter, dummy code, etc. Fixed bugs and duplications in SwiftTokenSets as well as plugin.xml. Improved documentation. Started work on fine tuning the LSP Initialize via an override of ClientCapabilities. So. Many. Closures. Just to serialize a schema of k/v pairs into JSON. In a standard that has had a json schema file available since 2022. In a world with code-gen. If the LSP wasn't mostly a stop-gap, I'd just reimplement all that myself properly, but it's likely not worth the time investment.